### PR TITLE
Remove old chapter markers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,6 +29,11 @@ To decrypt an `.aax` file, it's Activation Bytes are required. These will be the
 > This blurb is borrowed from the https://apprenticealf.wordpress.com/ page.
 
 1. Download an Audiobook `.aax` file from Audible and copy it to a work-directory.
+
+    These can be accessed directly from the Audible site from the Download button on the "My Books" page (under "Library"), <https://www.audible.com.au/lib>
+
+    Alternatively, they can be downloaded via the Audible app and the `.aax` file extracted from their application directory:
+
     * On Windows 10, get the Audbile App from the Microsoft Store and download an AudioBook. The files are located under `C:\Users\[username]\AppData\Local\Packages\AudibleInc.AudibleforWindowsPhone_xns73kv1ymhp2\LocalState\Content`
     * On Linux: ? (PR accepted!)
     * On MacOSX: ? (PR accepted!)

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -68,6 +68,7 @@ impl<'a> CliTool<&FfmpegOptions<'a>, (), io::Error> for FFMPEG {
             .arg("-qscale:a").arg(options.quality.to_string())
             .arg("-metadata").arg(&title)
             .arg("-metadata").arg(&track)
+            .arg("-map_chapters").arg("-1") // Clear old chapter markers
             .arg(out_file);
 
         debug!("transcode command: {:?}", command);


### PR DESCRIPTION
Thanks for this tool, very useful!

Adds the `-map_chapters -1` arg to ffmpeg to avoid leaving the chapter markers from the source `.aax` files in the output files (when the resulting files obviously don't need the chapter markers since they are split into file-per-chapter - these also confuse some players)

Also added to the README that the .aax files are easily downloadable via the Audible site without using the Audible app